### PR TITLE
Fix broken links on landing page

### DIFF
--- a/layouts/partials/landing_hero.html
+++ b/layouts/partials/landing_hero.html
@@ -12,11 +12,11 @@
 
 					{{ if .accent }}
 
-					<a href="{{ .title | safeURL }}" class="button button__accent">{{ .title | markdownify }}</a>
+					<a href="{{ .url | safeURL }}" class="button button__accent">{{ .title | markdownify }}</a>
 
 					{{ else }}
 
-					<a href="{{ .title | safeURL }}" class="button hero__button">{{ .title | markdownify }}</a>
+					<a href="{{ .url | safeURL }}" class="button hero__button">{{ .title | markdownify }}</a>
 
 					{{ end }}
 


### PR DESCRIPTION
The "Download Jellyfin" and "Learn more" links on the [homepage](https://jellyfin.org/) are broken. This fixes them.