### PR TITLE
Corrected hyperlink to the second Downloads button

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -73,5 +73,5 @@ cta:
   text: Check out our Getting Started guide to download and set up your server today.
   button:
     title: Download Jellyfin
-    url: /docs/general/#getting-started
+    url: /downloads
 ---


### PR DESCRIPTION
Hi Team,

Originally opened here: https://github.com/jellyfin/jellyfin.github.io/pull/42
The second button to Downloads was hyperlinked to "/docs/general/#getting-started", which was throwing a 404. I saw that the first button on that page was hyperlinked to "/downloads". I am opening a PR to change the 2nd hyperlink to "/downloads" instead. Thanks @anthonylavado for pointing me here.