### PR TITLE
Add mention of service in Debuntu

### DIFF
--- a/content/downloads/_index.md
+++ b/content/downloads/_index.md
@@ -95,6 +95,7 @@ wget -O - https://repo.jellyfin.org/jellyfin_team.gpg.key | sudo apt-key add -
 echo "deb [arch=$( dpkg --print-architecture )] https://repo.jellyfin.org/$( awk -F'=' '/^ID=/{ print $NF }' /etc/os-release ) $( awk -F'=' '/^VERSION_CODENAME=/{ print $NF }' /etc/os-release ) main" | sudo tee /etc/apt/sources.list.d/jellyfin.list
 sudo apt update
 sudo apt install jellyfin</code></pre>
+        <p>Once installed, Jellyfin will be running as a service. Manage it with <pre><code>sudo systemctl {action} jellyfin.service</code></pre> or <pre><code>sudo service jellyfin {action}</code></pre></p>
         </div>
         <div id="deb_repo_nightly" style="display:none;">
             <pre><code>sudo apt install apt-transport-https
@@ -102,6 +103,7 @@ wget -O - https://repo.jellyfin.org/jellyfin_team.gpg.key | sudo apt-key add -
 echo "deb [arch=$( dpkg --print-architecture )] https://repo.jellyfin.org/$( awk -F'=' '/^ID=/{ print $NF }' /etc/os-release ) $( awk -F'=' '/^VERSION_CODENAME=/{ print $NF }' /etc/os-release ) main" | sudo tee /etc/apt/sources.list.d/jellyfin.list
 sudo apt update
 sudo apt install jellyfin-nightly</code></pre>
+        <p>Once installed, Jellyfin will be running as a service. Manage it with <pre><code>sudo systemctl {action} jellyfin.service</code></pre> or <pre><code>sudo service jellyfin {action}</code></pre></p>
         </div>
     </div>
     <div class="arch">


### PR DESCRIPTION
Mention that the Debuntu packages install Jellyfin as a service, to help newcomers.

![Screenshot from 2020-02-18 23-01-14](https://user-images.githubusercontent.com/4031396/74800772-90752f80-52a2-11ea-9d85-fc938480c3c9.png)
