### PR TITLE
Fix clients page in chromium based browsers

### DIFF
--- a/assets/sass/custom.style.scss
+++ b/assets/sass/custom.style.scss
@@ -103,7 +103,6 @@
 	display: grid;
 	grid-gap: calc(var(--spacing) * 3.75);
 	grid-template-columns: repeat(3, 33.3%);
-	grid-auto-rows: 100%;
 	grid-auto-flow: dense;
 
 	@media only screen and (max-device-width: 560px) {


### PR DESCRIPTION
I noticed the new client page didn't work properly for me and after some digging I found out it was caused by the `grid-auto-rows` property. The fix was to just remove it and nothing visually changed.

**Before**  
![image](https://user-images.githubusercontent.com/2305178/77733078-87485280-7006-11ea-8965-83b6540b48d0.png)  
**After**  
![image](https://user-images.githubusercontent.com/2305178/77733085-89aaac80-7006-11ea-807a-a9a33b052aef.png)

Tested in both Vivaldi (chromium based) and Firefox