### PR TITLE
Correct the extension for macOS releases

### DIFF
--- a/content/downloads/_index.md
+++ b/content/downloads/_index.md
@@ -171,7 +171,7 @@ makepkg -si</code></pre>
     </div>
     <div class="macos">
         <h4>MacOS</h4>
-        <p>Both installers (.dmg) and manual ZIP archives (.zip) are provided.</p>
+        <p>Both installers (.dmg) and manual ZIP archives (.tar.gz) are provided.</p>
         <p>
             <a href="https://repo.jellyfin.org/releases/server/macos/stable" class="button button__accent">Stable</a>
             <a href="https://repo.jellyfin.org/releases/server/macos/nightly" class="button button__accent">Nightly</a>


### PR DESCRIPTION
Changes it from .zip to .tar.gz