### PR TITLE
Add Cloudron installation method

### DIFF
--- a/content/downloads/_index.md
+++ b/content/downloads/_index.md
@@ -159,6 +159,13 @@ makepkg -si</code></pre>
                 Versions</a>
         </p>
     </div>
+    <div class="cloudron">
+        <h4>Cloudron</h4>
+        <p>Install Jellyfin directly from the Cloudron app library.</p>
+        <p>
+            <a href="https://cloudron.io/button/org.jellyfin.cloudronapp.html" class="button button__accent">Stable</a>
+        </p>
+    </div>
     <div class="linux">
         <h4>Generic Linux</h4>
         <p>Linux self-contained binary TAR archives (.tar.gz) are provided.</p>


### PR DESCRIPTION
We have recently added Jellyfin to the Cloudron app library, so it would be great if Cloudron is added as an installation method.
Thanks :-)