### PR TITLE
Add opencollective contributor photo

### DIFF
--- a/content/contribute/_index.md
+++ b/content/contribute/_index.md
@@ -337,3 +337,8 @@ aliases = [
 							</div>
 						</div>
 				</div>
+
+## All the people that brought you Jellyfin
+<object data="https://opencollective.com/jellyfin/contributors.svg?width=1000&button=false" type="image/svg+xml" width="1000"></object>
+<br>
+


### PR DESCRIPTION
Adds a photo that shows all the contributors (with links to their GitHub profiles) to the "Contribute" page of the blog:

**Final look**

![image](https://user-images.githubusercontent.com/10274099/85208323-a9b0ea00-b32f-11ea-867d-4ac3cd917619.png)
