### PR TITLE
Theme landing Page, tweak clients and blog page and more

### DIFF
--- a/assets/js/libraries/contentFadeIn.js
+++ b/assets/js/libraries/contentFadeIn.js
@@ -9,13 +9,13 @@ const screenshotTxt = document.querySelectorAll(".screenshot__text");
 var Options = {
   root: null,
   rootMargin: '0px',
-  threshold: 0.85
+  threshold: 0.15
 };
 
 var TextOptions= {
   root: null,
   rootMargin: '0px',
-  threshold: 0.85
+  threshold: 0.1
 };
 
 if($(window).width()<400){

--- a/assets/js/libraries/contentFadeIn.js
+++ b/assets/js/libraries/contentFadeIn.js
@@ -1,0 +1,86 @@
+const stepImg = document.querySelectorAll(".fade_in_top_image");
+const stepTxt = document.querySelectorAll(".fade_in_top_text");
+const expandedMedia = document.querySelectorAll(".expanded__media");
+const expandedTitle = document.querySelectorAll(".expanded__title");
+const expandedText = document.querySelectorAll(".expanded_text");
+const screenshotMedia = document.querySelectorAll(".screenshot__media");
+const screenshotTxt = document.querySelectorAll(".screenshot__text");
+
+var Options = {
+  root: null,
+  rootMargin: '0px',
+  threshold: 0.85
+};
+
+var TextOptions= {
+  root: null,
+  rootMargin: '0px',
+  threshold: 0.85
+};
+
+if($(window).width()<400){
+  var Options = {
+    root: null,
+    rootMargin: '20px 0px 0px 0px',
+    threshold: 0.45
+  };
+  var TextOptions= {
+    root: null,
+    rootMargin: '5px',
+    threshold: 0.25
+  };
+}
+
+//
+const img = new IntersectionObserver(function(entries, afterHero){
+  entries.forEach( entry => {
+    if (!entry.isIntersecting) {
+      return;
+    }
+    else {
+      entry.target.classList.add("active__fade");
+      img.unobserve(entry.target);
+      console.log(entry.target);
+    }
+  });
+},Options)
+//
+const txt = new IntersectionObserver(function(entries, afterHero){
+  entries.forEach( entry => {
+    if (!entry.isIntersecting) {
+      return;
+    }
+    else {
+      entry.target.classList.add("active_fade_txt");
+      txt.unobserve(entry.target);
+    }
+  });
+},TextOptions)
+//
+stepImg.forEach(stepImg => {
+  img.observe(stepImg)
+});
+//
+stepTxt.forEach(stepTxt => {
+  txt.observe(stepTxt)
+});
+//
+expandedMedia.forEach(expandedMedia => {
+  img.observe(expandedMedia)
+});
+//
+expandedTitle.forEach(expandedTitle => {
+  txt.observe(expandedTitle)
+});
+//
+expandedText.forEach(expandedText => {
+  txt.observe(expandedText)
+});
+//
+screenshotMedia.forEach(screenshotMedia => {
+  img.observe(screenshotMedia)
+});
+//
+screenshotTxt.forEach(screenshotTxt => {
+  txt.observe(screenshotTxt)
+});

--- a/assets/js/libraries/parallax.js
+++ b/assets/js/libraries/parallax.js
@@ -1,0 +1,10 @@
+if ($(window).width() > 400 ){
+  $(window).scroll(function(){
+    parallax()
+  });
+}
+
+function parallax(){
+  var scrolled = $(window).scrollTop();
+  $(".hero").css('background-position','center calc(50% - '+scrolled*0.65+'px)');
+}

--- a/assets/sass/components/_cta.scss
+++ b/assets/sass/components/_cta.scss
@@ -30,3 +30,25 @@
 		text-align: center;
 	}
 }
+
+/*DOWNLOAD BUTTON*/
+@include desktop{
+	.cta .button__accent{
+		position: relative;
+		width: fit-content;
+	}
+
+	.cta .button__accent .bi.bi-cloud-download {
+		fill: #fff;
+		vertical-align: middle;
+		margin-right: -15px;
+		margin-left: auto;
+		opacity: 0;
+		transition: all .2s;
+	}
+
+	.cta .button__accent:hover .bi.bi-cloud-download {
+		margin-right: 5px;
+		opacity: 1;
+	}
+}

--- a/assets/sass/components/_expanded.scss
+++ b/assets/sass/components/_expanded.scss
@@ -47,7 +47,7 @@
 
 .expanded:nth-child(odd){
 	.expanded__content{
-		text-align: right;
+		text-align: left;
 	}
 	.expanded__title{
 		opacity: 0;

--- a/assets/sass/components/_expanded.scss
+++ b/assets/sass/components/_expanded.scss
@@ -52,7 +52,7 @@
 	.expanded__title{
 		opacity: 0;
 		transform: translateX(5%);
-		transition: opacity .35s ease-in-out, transform .35s ease-in-out;
+		transition: opacity .15s ease-in-out, transform .15s ease-in-out;
 
 		&.active_fade_txt{
 			opacity: 1;
@@ -70,8 +70,8 @@
 	.expanded_text.delayed{
 		opacity: 0;
 		transform: translateX(10%);
-		transition: opacity .25s ease-in-out, transform .25s ease-in-out;
-		transition-delay: .2s;
+		transition: opacity .15s ease-in-out, transform .15s ease-in-out;
+		transition-delay: .05s;
 
 		&.active_fade_txt{
 			opacity: 1;
@@ -88,7 +88,7 @@
 	.expanded__media {
 		opacity: 0;
 		transform: translateX(-5%);
-		transition: opacity .35s ease-in-out, transform .35s ease-in-out;
+		transition: opacity .15s ease-in-out, transform .15s ease-in-out;
 
 		&.active__fade{
 			opacity: 1;
@@ -113,7 +113,7 @@
 	.expanded__title{
 		opacity: 0;
 		transform: translateX(-5%);
-		transition: opacity .35s ease-in-out, transform .35s ease-in-out;
+		transition: opacity .15s ease-in-out, transform .15s ease-in-out;
 
 		&.active_fade_txt{
 			opacity: 1;
@@ -131,8 +131,8 @@
 	.expanded_text.delayed{
 		opacity: 0;
 		transform: translateX(-10%);
-		transition: opacity .25s ease-in-out, transform .25s ease-in-out;
-		transition-delay: .2s;
+		transition: opacity .15s ease-in-out, transform .15s ease-in-out;
+		transition-delay: .05s;
 
 		&.active_fade_txt{
 			opacity: 1;
@@ -150,7 +150,7 @@
 	.expanded__media {
 		opacity: 0;
 		transform: translateX(5%);
-		transition: opacity .35s ease-in-out, transform .35s ease-in-out;
+		transition: opacity .15s ease-in-out, transform .15s ease-in-out;
 
 		&.active__fade{
 			opacity: 1;

--- a/assets/sass/components/_expanded.scss
+++ b/assets/sass/components/_expanded.scss
@@ -16,7 +16,7 @@
 .expanded__media {
 	order: 1;
 	text-align: center;
-	
+
 	@include desktop {
 		width: 50%;
 		flex-shrink: 0;
@@ -26,7 +26,7 @@
 
 .expanded__content {
 	order: 2;
-	
+
 	@include desktop {
 		padding: 0 16pt;
 		width: 50%;
@@ -41,6 +41,128 @@
 
 		@include desktop {
 			order: 1;
+		}
+	}
+}
+
+.expanded:nth-child(odd){
+	.expanded__content{
+		text-align: right;
+	}
+	.expanded__title{
+		opacity: 0;
+		transform: translateX(5%);
+		transition: opacity .35s ease-in-out, transform .35s ease-in-out;
+
+		&.active_fade_txt{
+			opacity: 1;
+			transform: translateX(0);
+		}
+
+		@include phone {
+			transform: translateX(0) translateY(10%);
+
+			&.active_fade_txt{
+				transform: translateX(0) translateY(0);
+			}
+		}
+	}
+	.expanded_text.delayed{
+		opacity: 0;
+		transform: translateX(10%);
+		transition: opacity .25s ease-in-out, transform .25s ease-in-out;
+		transition-delay: .2s;
+
+		&.active_fade_txt{
+			opacity: 1;
+			transform: translateX(0);
+		}
+		@include phone {
+			transform: translateX(0) translateY(10%);
+
+			&.active_fade_txt{
+				transform: translateX(0) translateY(0);
+			}
+		}
+	}
+	.expanded__media {
+		opacity: 0;
+		transform: translateX(-5%);
+		transition: opacity .35s ease-in-out, transform .35s ease-in-out;
+
+		&.active__fade{
+			opacity: 1;
+			transform: translateX(0);
+		}
+		@include phone {
+			transform: translateX(0) translateY(25%);
+
+			&.active__fade{
+				transform: translateX(0) translateY(0);
+			}
+		}
+	}
+}
+
+.expanded {
+	@include phone {
+		.expanded__content{
+			text-align: center !important;
+		}
+	}
+	.expanded__title{
+		opacity: 0;
+		transform: translateX(-5%);
+		transition: opacity .35s ease-in-out, transform .35s ease-in-out;
+
+		&.active_fade_txt{
+			opacity: 1;
+			transform: translateX(0);
+		}
+
+		@include phone {
+			transform: translateX(0) translateY(10%);
+
+			&.active_fade_txt{
+				transform: translateX(0) translateY(0);
+			}
+		}
+	}
+	.expanded_text.delayed{
+		opacity: 0;
+		transform: translateX(-10%);
+		transition: opacity .25s ease-in-out, transform .25s ease-in-out;
+		transition-delay: .2s;
+
+		&.active_fade_txt{
+			opacity: 1;
+			transform: translateX(0);
+		}
+
+		@include phone {
+			transform: translateX(0) translateY(10%);
+
+			&.active_fade_txt{
+				transform: translateX(0) translateY(0);
+			}
+		}
+	}
+	.expanded__media {
+		opacity: 0;
+		transform: translateX(5%);
+		transition: opacity .35s ease-in-out, transform .35s ease-in-out;
+
+		&.active__fade{
+			opacity: 1;
+			transform: translateX(0);
+		}
+
+		@include phone {
+			transform: translateX(0) translateY(10%);
+
+			&.active__fade{
+				transform: translateX(0) translateY(0);
+			}
 		}
 	}
 }

--- a/assets/sass/components/_footer.scss
+++ b/assets/sass/components/_footer.scss
@@ -1,5 +1,5 @@
 .footer {
-	background-color: $background;
+	background-color: $background-alt;
 	padding: 36pt 0;
 }
 
@@ -74,7 +74,7 @@
 
 /*--- Modifiers---*/
 .footer--dark {
-	background-color: $background-dark;
+	background-color: $background-alt;
 
 	.footer__textLogo {
 		color: #fff;

--- a/assets/sass/components/_gallery.scss
+++ b/assets/sass/components/_gallery.scss
@@ -36,7 +36,7 @@
 	margin: 16pt 0;
 	opacity: 0;
 	transform: translateY(20%);
-	transition: transform .35s, opacity .35s;
+	transition: transform .15s, opacity .15s;
 
 	&.active__fade{
 		opacity: 1;
@@ -74,8 +74,8 @@
 	margin-right: auto;
 	opacity: 0;
 	transform: translateY(20%);
-	transition: opacity .35s, transform .35s;
-	transition-delay: .3s;
+	transition: opacity .15s, transform .15s;
+	transition-delay: .05s;
 
 	&.active_fade_txt{
 		opacity: 1;

--- a/assets/sass/components/_gallery.scss
+++ b/assets/sass/components/_gallery.scss
@@ -34,6 +34,14 @@
 
 .screenshot__media {
 	margin: 16pt 0;
+	opacity: 0;
+	transform: translateY(20%);
+	transition: transform .35s, opacity .35s;
+
+	&.active__fade{
+		opacity: 1;
+		transform: translateY(0);
+	}
 }
 
 @media (min-width: 992px) {
@@ -64,4 +72,13 @@
 	text-align: center;
 	margin-left: auto;
 	margin-right: auto;
+	opacity: 0;
+	transform: translateY(20%);
+	transition: opacity .35s, transform .35s;
+	transition-delay: .3s;
+
+	&.active_fade_txt{
+		opacity: 1;
+		transform: translateY(0);
+	}
 }

--- a/assets/sass/components/_hero.scss
+++ b/assets/sass/components/_hero.scss
@@ -1,11 +1,12 @@
 .hero {
   position: relative;
   width: 100%;
-  background-image: url("../images/background.jpg");
-  background-size: cover;
-  background-position: center center;
-  background-repeat: no-repeat;
   color: $hero-color;
+  background: url("../images/background.jpg");
+  background-attachment: fixed;
+  background-size: cover;
+  background-repeat: no-repeat;
+  background-position: 50%;
 
   &__inner {
     position: relative;
@@ -40,7 +41,7 @@
   position: absolute;
   height: 100%;
   width: 100%;
-  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="1920" height="1080" viewBox="0 0 1920 1080"><defs><linearGradient id="06714b97-aec8-4b7e-bf3d-1e20f95f612e" y1="809.5" x2="958" y2="809.5" gradientTransform="matrix(1, 0, 0, -1, 0, 1082)" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#fff" stop-opacity="0"/><stop offset="1" stop-color="#fff" stop-opacity="0.05"/></linearGradient></defs><title>hero</title><rect id="0567095b-2cf7-4407-b8ab-ec2abe52d830" data-name="&lt;Path&gt;" y="545" width="1920" height="535" fill="#fff" opacity="0.05" style="isolation:isolate"/><polygon id="82ca9a61-a0a1-49cc-9805-a3533c693bad" data-name="&lt;Path&gt;" points="958 545 0 545 0 0 770.96 0 958 545" fill="url(#06714b97-aec8-4b7e-bf3d-1e20f95f612e)"/></svg>');
+  background-image: url(data:image/svg+xml;utf8;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB3aWR0aD0iMTkyMCIgaGVpZ2h0PSIxMDgwIiB2aWV3Qm94PSIwIDAgMTkyMCAxMDgwIj48ZGVmcz48bGluZWFyR3JhZGllbnQgaWQ9IjA2NzE0Yjk3LWFlYzgtNGI3ZS1iZjNkLTFlMjBmOTVmNjEyZSIgeTE9IjgwOS41IiB4Mj0iOTU4IiB5Mj0iODA5LjUiIGdyYWRpZW50VHJhbnNmb3JtPSJtYXRyaXgoMSwgMCwgMCwgLTEsIDAsIDEwODIpIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSI+PHN0b3Agb2Zmc2V0PSIwIiBzdG9wLWNvbG9yPSIjZmZmIiBzdG9wLW9wYWNpdHk9IjAiLz48c3RvcCBvZmZzZXQ9IjEiIHN0b3AtY29sb3I9IiNmZmYiIHN0b3Atb3BhY2l0eT0iLjA1Ii8+PC9saW5lYXJHcmFkaWVudD48L2RlZnM+PHRpdGxlPmhlcm88L3RpdGxlPjxyZWN0IGlkPSIwNTY3MDk1Yi0yY2Y3LTQ0MDctYjhhYi1lYzJhYmU1MmQ4MzAiIGRhdGEtbmFtZT0iJmx0O1BhdGg+IiB5PSI1NDUiIHdpZHRoPSIxOTIwIiBoZWlnaHQ9IjUzNSIgZmlsbD0iI2ZmZiIgb3BhY2l0eT0iLjA1IiBzdHlsZT0iaXNvbGF0aW9uOmlzb2xhdGUiLz48cG9seWdvbiBpZD0iODJjYTlhNjEtYTBhMS00OWNjLTk4MDUtYTM1MzNjNjkzYmFkIiBkYXRhLW5hbWU9IiZsdDtQYXRoPiIgcG9pbnRzPSI5NTggNTQ1IDAgNTQ1IDAgMCA3NzAuOTYgMCA5NTggNTQ1IiBmaWxsPSJ1cmwoIzA2NzE0Yjk3LWFlYzgtNGI3ZS1iZjNkLTFlMjBmOTVmNjEyZSkiLz48L3N2Zz4=);
   background-size: cover;
   background-position: center center;
   background-repeat: no-repeat;
@@ -86,6 +87,11 @@
 .hero__button {
   color: $hero-color;
   border-color: $hero-color;
+  transition: all .2s;
+
+  &:hover{
+    background: rgba(255,255,255,0.1);
+  }
 
   @include desktop {
     &:hover {
@@ -132,4 +138,24 @@
 
 .hero--full + .hero__sub {
   display: none;
+}
+
+/*DOWNLOAD BUTTON*/
+@include desktop{
+  .hero .button__accent{
+    position: relative;
+    width: fit-content;
+  }
+  .hero .button__accent .bi.bi-cloud-download {
+    fill: #fff;
+    vertical-align: middle;
+    margin-right: -15px;
+    margin-left: auto;
+    opacity: 0;
+    transition: all .2s;
+  }
+  .hero .button__accent:hover .bi.bi-cloud-download {
+    margin-right: 5px;
+    opacity: 1;
+  }
 }

--- a/assets/sass/components/_navbar.scss
+++ b/assets/sass/components/_navbar.scss
@@ -70,11 +70,13 @@
 				display: block;
 				content: "";
 				border-bottom: solid 1px #fff;
+				transform-origin: right;
 				transform: scaleX(0);
 				transition: transform 250ms ease-in-out;
 			}
 
 			&:hover:after {
+				transform-origin: left;
 				transform: scaleX(1);
 			}
 		}

--- a/assets/sass/components/_navbar.scss
+++ b/assets/sass/components/_navbar.scss
@@ -3,7 +3,7 @@
 	z-index: 100;
 	width: 100%;
 	background-color: $background;
-	transition: 0.7s;
+	transition: 0.5s;
 
 	&--nofixed {
 		position: relative;
@@ -113,7 +113,7 @@
 	width: 100%;
 	display: block;
 	list-style: none;
-	background-color: $background-dark;
+	background-color: $background-alt;
 	color: #fff;
 }
 

--- a/assets/sass/components/_page.scss
+++ b/assets/sass/components/_page.scss
@@ -40,7 +40,7 @@
 .subtitle_link {
 	border-bottom: 1px dotted #fafafa;
 	padding-bottom: 1pt;
-	transition: 0.7s;
+	transition: 0.3s;
 
 	@include desktop {
 		&:hover {
@@ -126,6 +126,11 @@ blockquote {
 
 	a{
 		border: none !important;
+
+		&::after{
+			display: none;
+		}
+
 	}
 
 	&::after{
@@ -136,40 +141,13 @@ blockquote {
 		left: 0;
 		bottom: -10%;
 		background: #6c63ff;
-		transition: width .7s ease-in-out, background .7s;
+		transition: width .3s ease-in-out, background .3s;
 	}
 
 	&:hover{
 		&::after{
 			background: #fff;
 			width: 100%;
-		}
-	}
-}
-
-time + span + a{
-	width: fit-content;
-	position: relative;
-	border: none !important;
-
-	&::after{
-		content: "";
-		position: absolute;
-		width: 100%;
-		height: 1px;
-		left: 0;
-		bottom: 0%;
-		background: #6c63ff;
-		transition: transform .7s ease-in-out, background .7s, opacity .7s;
-		transform: scaleX(0);
-		transform-origin: right;
-	}
-
-	&:hover{
-		&::after{
-			transform-origin: left;
-			transform: scaleX(1);
-			background: #fff;
 		}
 	}
 }
@@ -190,6 +168,33 @@ time + span + a{
 	}
 }
 
+
+a:not(.button, .navbar__logo){
+	width: fit-content;
+	position: relative;
+	border: none !important;
+
+	&::after{
+		content: "";
+		position: absolute;
+		width: 100%;
+		height: 1px;
+		left: 0;
+		bottom: -5%;
+		background: #fff;
+		transition: transform .3s ease-in-out, background .3s, opacity .3s;
+		transform: scaleX(0);
+		transform-origin: right;
+	}
+
+	&:hover{
+		&::after{
+			transform-origin: left;
+			transform: scaleX(1);
+			background: #fff;
+		}
+	}
+}
 //Highlight
 *{
 	&::selection{

--- a/assets/sass/components/_page.scss
+++ b/assets/sass/components/_page.scss
@@ -1,7 +1,6 @@
 .page__header {
 	position: relative;
 	color: $hero-color;
-	box-shadow: $hero-shadow;
 	width: 100%;
 }
 
@@ -93,7 +92,7 @@
 }
 
 .read-more{
-    text-align: right;
+	text-align: right;
 }
 
 .post-block{
@@ -119,4 +118,81 @@ blockquote {
 	font-style: italic;
 	background-color: #222;
 	border-left: 3px solid #ccc;
+}
+
+.post-title{
+	position: relative;
+	width: fit-content;
+
+	a{
+		border: none !important;
+	}
+
+	&::after{
+		content:"";
+		position: absolute;
+		width: 10%;
+		height: 1px;
+		left: 0;
+		bottom: -10%;
+		background: #6c63ff;
+		transition: width .7s ease-in-out, background .7s;
+	}
+
+	&:hover{
+		&::after{
+			background: #fff;
+			width: 100%;
+		}
+	}
+}
+
+time + span + a{
+	width: fit-content;
+	position: relative;
+	border: none !important;
+
+	&::after{
+		content: "";
+		position: absolute;
+		width: 100%;
+		height: 1px;
+		left: 0;
+		bottom: 0%;
+		background: #6c63ff;
+		transition: transform .7s ease-in-out, background .7s, opacity .7s;
+		transform: scaleX(0);
+		transform-origin: right;
+	}
+
+	&:hover{
+		&::after{
+			transform-origin: left;
+			transform: scaleX(1);
+			background: #fff;
+		}
+	}
+}
+
+.page{
+	p + h2 {
+		position: relative;
+
+		&::after {
+			content: "";
+			position: absolute;
+			bottom: -5%;
+			left: 2px;
+			height: 1px;
+			width: 6%;
+			background: #fff;
+		}
+	}
+}
+
+//Highlight
+*{
+	&::selection{
+		background: $secondary;
+	}
 }

--- a/assets/sass/components/_steps.scss
+++ b/assets/sass/components/_steps.scss
@@ -1,13 +1,14 @@
 .steps {
 	text-align: center;
 	padding: 16pt 0;
+	overflow: hidden;
 }
 
 .steps__inner {
 	@include desktop {
-		   -js-display: flex;
-		   display: flex;
-		   justify-content: space-around;
+		-js-display: flex;
+		display: flex;
+		justify-content: space-around;
 	}
 }
 
@@ -49,7 +50,30 @@
 
 .step__text {
 	max-width: 25ch;
-  	text-align: center;
-  	margin-left: auto;
-  	margin-right: auto;
+	text-align: center;
+	margin-left: auto;
+	margin-right: auto;
+}
+
+.fade_in_top_image {
+  opacity: 0;
+  transition: opacity .35s ease-in, transform .35s ease-in;
+  transform: translateY(10%);
+
+  &.active__fade {
+    opacity: 100%;
+    transform: translateY(0);
+  }
+}
+
+.fade_in_top_text {
+	opacity: 0;
+	transform: translateY(60%);
+	transition: opacity .25s, transform .25s;
+	transition-delay: .3s;
+
+	&.active_fade_txt{
+		opacity: 1;
+		transform: translateY(0);
+	}
 }

--- a/assets/sass/components/_steps.scss
+++ b/assets/sass/components/_steps.scss
@@ -9,6 +9,7 @@
 		-js-display: flex;
 		display: flex;
 		justify-content: space-around;
+		grid-gap: 20px;
 	}
 }
 
@@ -57,7 +58,7 @@
 
 .fade_in_top_image {
   opacity: 0;
-  transition: opacity .35s ease-in, transform .35s ease-in;
+  transition: opacity .15s ease-in, transform .15s ease-in;
   transform: translateY(10%);
 
   &.active__fade {
@@ -69,8 +70,8 @@
 .fade_in_top_text {
 	opacity: 0;
 	transform: translateY(60%);
-	transition: opacity .25s, transform .25s;
-	transition-delay: .3s;
+	transition: opacity .15s, transform .15s;
+	transition-delay: .05s;
 
 	&.active_fade_txt{
 		opacity: 1;

--- a/assets/sass/custom.style.scss
+++ b/assets/sass/custom.style.scss
@@ -125,7 +125,7 @@
 		transition: all 250ms;
 		font-size: 0.9em;
 		text-align: center;
-		border-radius: 10px;
+		border-radius: 3px;
 
 		.bannerbox {
 			margin-top: 1.5em;

--- a/assets/sass/custom.style.scss
+++ b/assets/sass/custom.style.scss
@@ -10,7 +10,7 @@
 		margin-top: 2.2em;
 		position: absolute;
 		bottom: 20px;
-		text-align: center;	
+		text-align: center;
 		width: 100%;
 		left: 0;
 		font-size: 0.7em;
@@ -125,6 +125,7 @@
 		transition: all 250ms;
 		font-size: 0.9em;
 		text-align: center;
+		border-radius: 10px;
 
 		.bannerbox {
 			margin-top: 1.5em;
@@ -166,7 +167,7 @@
 				color: #fff;
 			}
 		}
-	}	
+	}
 }
 
 video.justify {

--- a/assets/sass/elements/_buttons.scss
+++ b/assets/sass/elements/_buttons.scss
@@ -7,13 +7,12 @@ button,
 	border: 1px solid $primary;
 	color: $primary;
 	font-weight: $normal;
-	transition: 0.7s;
+	transition:.2s;
 	white-space: nowrap;
 	cursor: pointer;
 	background-color: transparent;
 	border-radius: $radius;
 	margin-bottom: 1.3em;
-	transition: 0.7s;
 	text-align: center;
 	text-decoration: none;
 
@@ -22,10 +21,13 @@ button,
 		outline: 0;
 	}
 
+
 	@include desktop {
 		&:hover {
 			border-color: $primary-dark;
 			color: $primary-dark;
+			transform: scale(1.065) translateY(-3px);
+			box-shadow: 0px 7px 15px rgba(5,5,5,0.5);
 		}
 	}
 }
@@ -54,6 +56,12 @@ button,
 			background-color: darken($accent, 4%);
 			border-color: darken($accent, 4%);
 			color: #fff;
+		}
+	}
+
+	@include phone {
+		svg{
+			display: none !important;
 		}
 	}
 }

--- a/assets/sass/elements/_scrollbar.scss
+++ b/assets/sass/elements/_scrollbar.scss
@@ -1,0 +1,13 @@
+body{
+  overflow-y:overlay;
+}
+
+*{
+  &::-webkit-scrollbar{
+    width:5px;
+    background: transparent;
+  }
+  &::-webkit-scrollbar-thumb{
+    background: $background-dark;
+  }
+}

--- a/assets/sass/style.scss
+++ b/assets/sass/style.scss
@@ -14,6 +14,7 @@
 @import "elements/forms";
 
 // Components
+@import "components/fade";
 @import "components/landing";
 @import "components/navbar";
 @import "components/hero";

--- a/assets/sass/style.scss
+++ b/assets/sass/style.scss
@@ -12,6 +12,7 @@
 @import "elements/typography";
 @import "elements/buttons";
 @import "elements/forms";
+@import "elements/scrollbar";
 
 // Components
 @import "components/fade";

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,13 +1,13 @@
 <head>
   <meta charset="utf-8" />
   <meta
-    name="viewport"
-    content="width=device-width, initial-scale=1, maximum-scale=1"
+  name="viewport"
+  content="width=device-width, initial-scale=1, maximum-scale=1"
   />
   <title>{{ .Title }} {{ if .Title }}-{{ end }} {{ .Site.Title }}</title>
 
   {{- range .AlternativeOutputFormats -}}
-    {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
+  {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
   {{- end -}}
 
   <link rel="shortcut icon" href="/favicon.ico" />
@@ -21,7 +21,9 @@
   <!-- Elements -->
   {{ $e7 := resources.Get "sass/elements/_typography.scss" }}
   {{ $e8 := resources.Get "sass/elements/_buttons.scss" }}
+  {{ $e9 := resources.Get "sass/elements/_scrollbar.scss" }}
   {{ $e10 := resources.Get "sass/elements/_forms.scss" }}
+
   <!-- Components -->
   {{ $e11 := resources.Get "sass/components/_landing.scss" }}
   {{ $e12 := resources.Get "sass/components/_navbar.scss" }}
@@ -37,7 +39,7 @@
   {{ $e22 := resources.Get "sass/components/_gallery.scss" }}
   {{ $c := resources.Get "sass/custom.style.scss" }}
 
-  {{ $style := slice $e1 $e2 $e3 $e4 $e5 $e6 $e7 $e8 $e10 $e11 $e12 $e13 $e14 $e15 $e16 $e17 $e18 $e19 $e20 $e21 $e22 $c | resources.Concat "css/style.css" | resources.ToCSS | fingerprint | minify }}
+  {{ $style := slice $e1 $e2 $e3 $e4 $e5 $e6 $e7 $e8 $e9 $e10 $e11 $e12 $e13 $e14 $e15 $e16 $e17 $e18 $e19 $e20 $e21 $e22 $c | resources.Concat "css/style.css" | resources.ToCSS | fingerprint | minify }}
 
   <link rel="stylesheet" type="text/css" href="{{ $style.RelPermalink }}" />
   <link rel="stylesheet" href="/css/juxtapose.css">

--- a/layouts/partials/landing_about.html
+++ b/layouts/partials/landing_about.html
@@ -7,9 +7,9 @@
         <div class="steps__inner">
             {{ range $i, $box :=  .Params.about.box }}
             <div class="step">
-                <div class="step__media"><img src="{{ $box.src }}" alt="{{ $box.alt }}" class="step__image"></div>
-                <h4>{{ $box.title | markdownify }}</h4>
-                <p class="step__text">{{ $box.text | markdownify }}</p>
+                <div class="step__media fade_in_top_image"><img src="{{ $box.src }}" alt="{{ $box.alt }}" class="step__image"></div>
+                <h4 class="fade_in_top_text">{{ $box.title | markdownify }}</h4>
+                <p class="step_text fade_in_top_text">{{ $box.text | markdownify }}</p>
             </div>
             {{ end }}
         </div>

--- a/layouts/partials/landing_cta.html
+++ b/layouts/partials/landing_cta.html
@@ -4,7 +4,7 @@
 		<div class="cta__inner">
 			<h2 class="cta__title">{{ .Params.cta.title }}</h2>
 			<p class="cta__sub cta__sub--center">{{ .Params.cta.text | markdownify }}</p>
-			<a href="{{ .Params.cta.button.url | safeURL }}" class="button button__accent">{{ .Params.cta.button.title | markdownify }}</a>
+			<a href="{{ .Params.cta.button.url | safeURL }}" class="button button__accent"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-cloud-download" viewBox="0 0 16 16"><path d="M4.406 1.342A5.53 5.53 0 0 1 8 0c2.69 0 4.923 2 5.166 4.579C14.758 4.804 16 6.137 16 7.773 16 9.569 14.502 11 12.687 11H10a.5.5 0 0 1 0-1h2.688C13.979 10 15 8.988 15 7.773c0-1.216-1.02-2.228-2.313-2.228h-.5v-.5C12.188 2.825 10.328 1 8 1a4.53 4.53 0 0 0-2.941 1.1c-.757.652-1.153 1.438-1.153 2.055v.448l-.445.049C2.064 4.805 1 5.952 1 7.318 1 8.785 2.23 10 3.781 10H6a.5.5 0 0 1 0 1H3.781C1.708 11 0 9.366 0 7.318c0-1.763 1.266-3.223 2.942-3.593.143-.863.698-1.723 1.464-2.383z"/><path d="M7.646 15.854a.5.5 0 0 0 .708 0l3-3a.5.5 0 0 0-.708-.708L8.5 14.293V5.5a.5.5 0 0 0-1 0v8.793l-2.146-2.147a.5.5 0 0 0-.708.708l3 3z"/></svg>{{ .Params.cta.button.title | markdownify }}</a>
 		</div>
 	</div>
 </div>

--- a/layouts/partials/landing_gallery.html
+++ b/layouts/partials/landing_gallery.html
@@ -22,7 +22,7 @@
 						<img src="{{ .src }}_thumb.png" alt="{{ .alt }}" class="screenshot__image" />
 					</a>
 				</div>
-				<h4>{{ .imgtitle | markdownify }}</h4>
+				<h4 class="screenshot__text">{{ .imgtitle | markdownify }}</h4>
 			</div>
 			{{ end }}
 		</div>

--- a/layouts/partials/landing_hero.html
+++ b/layouts/partials/landing_hero.html
@@ -9,7 +9,7 @@
 					<p class="hero__text">{{ .Params.hero.text | markdownify }}</p>
 					{{ range .Params.hero.button }}
 					{{ if .accent }}
-					<a href="{{ .url | safeURL }}" class="button button__accent">{{ .title | markdownify }}</a>
+					<a href="{{ .url | safeURL }}" class="button button__accent"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-cloud-download" viewBox="0 0 16 16"><path d="M4.406 1.342A5.53 5.53 0 0 1 8 0c2.69 0 4.923 2 5.166 4.579C14.758 4.804 16 6.137 16 7.773 16 9.569 14.502 11 12.687 11H10a.5.5 0 0 1 0-1h2.688C13.979 10 15 8.988 15 7.773c0-1.216-1.02-2.228-2.313-2.228h-.5v-.5C12.188 2.825 10.328 1 8 1a4.53 4.53 0 0 0-2.941 1.1c-.757.652-1.153 1.438-1.153 2.055v.448l-.445.049C2.064 4.805 1 5.952 1 7.318 1 8.785 2.23 10 3.781 10H6a.5.5 0 0 1 0 1H3.781C1.708 11 0 9.366 0 7.318c0-1.763 1.266-3.223 2.942-3.593.143-.863.698-1.723 1.464-2.383z"/><path d="M7.646 15.854a.5.5 0 0 0 .708 0l3-3a.5.5 0 0 0-.708-.708L8.5 14.293V5.5a.5.5 0 0 0-1 0v8.793l-2.146-2.147a.5.5 0 0 0-.708.708l3 3z"/></svg>{{ .title | markdownify }}</a>
 					{{ else if .scroll}}
 					<a href="{{ .url | safeURL }}" class="button hero__button scroll">{{ .title | markdownify }}</a>
 					{{ else }}

--- a/layouts/partials/landing_single.html
+++ b/layouts/partials/landing_single.html
@@ -13,7 +13,7 @@
 				{{ .spectext | safeHTML }}
 				{{ else }}
 				{{ if not ( findRE "<[h|p][^>]*>" $markdown ) }}
-				<p class="expanded_text">{{ $markdown }}</p>
+				<p class="expanded_text delayed">{{ $markdown }}</p>
 				{{ else }}
 				{{ $markdown }}
 				{{ end }}

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -12,6 +12,8 @@
 	{{ $js1 := resources.Get "js/app.js" }}
 	{{ $js2 := resources.Get "js/libraries/flexibility.js" }}
 	{{ $js3 := resources.Get "js/libraries/responsive-nav.js" }}
-	{{ $js := slice $js1 $js2 $js3  | resources.Concat "js/scripts.js" | minify | fingerprint }}
+	{{ $js4 := resources.Get "js/libraries/contentFadeIn.js" }}
+	{{ $js5 := resources.Get "js/libraries/parallax.js" }}
+	{{ $js := slice $js1 $js2 $js3 $js4 $js5 | resources.Concat "js/scripts.js" | minify | fingerprint }}
 	<script type="text/javascript" src="{{ $js.RelPermalink }}"></script>
 </div>


### PR DESCRIPTION
I have tweaked the current landing page in the following ways:

- Fade-in content when scrolling using intersection observer API
- Text alignment fixed for images on the left side (CSS only)
- Parallex hero background 

Client Page tweaks: 

- Rounded edges for client cards (CSS only)

Blog Page tweaks: 

- Title of the blogs have a small underline without dotted lines (CSS only)
- The name of the author will have an underline on the hover (CSS only)
- Add a fixed width underline for blog title-topics (CSS only)

Nav Menu tweaks:

- Change hover style for options to come in from the left and go to the right (CSS only).
- Change options background on phone. (CSS only)

Universal tweaks:

- Add selection highlight color (CSS only)
- Change button hover style (CSS only)


All changes can be seen at [here](https://jellyfin-website.prayagnet.tk/)