### PR TITLE
Add blog post about Android beta programs

### DIFF
--- a/content/posts/android-betas.md
+++ b/content/posts/android-betas.md
@@ -8,13 +8,13 @@ justify: 'center'
 ---
 <!-- markdownlint-disable MD033 -->
 
-With the release of the first Android TV 0.12 release beta this is a good time to explain how our Android beta programs work and how you can start using it. The mobile app has used a public beta channel for around a year now and with the Android TV app coming close to a new release we're adding a similar program for that as well.
+With the release of the first Android TV 0.12 release beta, this is a good time to explain how our Android beta programs work and how to start using them. The mobile app has used a public beta channel for around a year now and with the Android TV app coming close to a new release we're adding a similar program for that as well.
 
 <!--more-->
 
 ## What is the difference between release and beta?
 
-A beta version is an early build of an upcoming release. This means that most of the new features are available but there might still be some issues. In the case of the Jellyfin android apps we might release a beta version because we expect issues or want to test something with a larger audience. Generally the beta cycle should only last a short period.
+A beta version is an early build of an upcoming release. This means that most of the new features are available but there might still be some issues. In the case of the Jellyfin android apps, we might release a beta version because we expect issues or want to test something with a larger audience. Generally the beta cycle should only last a short period.
 
 ## Should I use a beta version?
 
@@ -22,7 +22,7 @@ Beta versions may contain issues. Those issues could vary from a small annoyance
 
 ## How do I report problems?
 
-If you encounter a problem we would appreciate a detailed issue with app-logs and reproducible steps so we can fix your problem before release. To do this you will need an account on GitHub and open an issue on the repository for the app.
+If you encounter a problem, we would appreciate a detailed issue with app-logs and reproducible steps so we can fix the problem before release. To do this, you will need an account on GitHub and open an issue on the repository for the app.
 
 - [GitHub issues Android TV](https://github.com/jellyfin/jellyfin-androidtv/issues/new/choose)
 - [GitHub issues Android (mobile)](https://github.com/jellyfin/jellyfin-android/issues/new/choose)

--- a/content/posts/android-betas.md
+++ b/content/posts/android-betas.md
@@ -1,0 +1,48 @@
+---
+title: 'Regarding the Android betas'
+subtitle: 'A small FAQ about our beta programs'
+author: 'Niels van Velzen'
+githubusername: 'nielsvanvelzen'
+date: 2021-07-16T00:00:00-00:00
+justify: 'center'
+---
+<!-- markdownlint-disable MD033 -->
+
+With the release of the first Android TV 0.12 release beta this is a good time to explain how our Android beta programs work and how you can start using it. The mobile app has used a public beta channel for around a year now and with the Android TV app coming close to a new release we're adding a similar program for that as well.
+
+<!--more-->
+
+## What is the difference between release and beta?
+
+A beta version is an early build of an upcoming release. This means that most of the new features are available but there might still be some issues. In the case of the Jellyfin android apps we might release a beta version because we expect issues or want to test something with a larger audience. Generally the beta cycle should only last a short period.
+
+## Should I use a beta version?
+
+Beta versions may contain issues. Those issues could vary from a small annoyance to a major issue that prevents you from signing in to your server. Do not use a beta version if you are unable to provide bug reports with app-logs and reproducible steps.
+
+## How do I report problems?
+
+If you encounter a problem we would appreciate a detailed issue with app-logs and reproducible steps so we can fix your problem before release. To do this you will need an account on GitHub and open an issue on the repository for the app.
+
+- [GitHub issues Android TV](https://github.com/jellyfin/jellyfin-androidtv/issues/new/choose)
+- [GitHub issues Android (mobile)](https://github.com/jellyfin/jellyfin-android/issues/new/choose)
+
+## Where do I get the beta?
+
+The beta releases are only available on the Google Play store or in our own repository. Users of F-Droid or the Amazon Appstore can sideload the apk files available in our repository or wait for the release.
+
+### Android TV
+
+<a class="NoLinkLook" href="https://play.google.com/apps/testing/org.jellyfin.androidtv">
+  <img width="153" alt="Jellyfin for Android TV on Google Play" src="/images/store-icons/google-play.png" />
+</a>
+
+Direct downloads available in [our repository](https://repo.jellyfin.org/releases/client/androidtv/).
+
+### Android (mobile)
+
+<a class="NoLinkLook" href="https://play.google.com/apps/testing/org.jellyfin.mobile">
+  <img width="153" alt="Jellyfin on Google Play" src="/images/store-icons/google-play.png" />
+</a>
+
+Direct downloads available in [our repository](https://repo.jellyfin.org/releases/client/android/).

--- a/content/posts/android-betas.md
+++ b/content/posts/android-betas.md
@@ -3,7 +3,7 @@ title: 'Regarding the Android betas'
 subtitle: 'A small FAQ about our beta programs'
 author: 'Niels van Velzen'
 githubusername: 'nielsvanvelzen'
-date: 2021-07-16T00:00:00-00:00
+date: 2021-07-24T00:00:00-00:00
 justify: 'center'
 ---
 <!-- markdownlint-disable MD033 -->
@@ -14,7 +14,7 @@ With the release of the first Android TV 0.12 release beta, this is a good time 
 
 ## What is the difference between release and beta?
 
-A beta version is an early build of an upcoming release. This means that most of the new features are available but there might still be some issues. In the case of the Jellyfin android apps, we might release a beta version because we expect issues or want to test something with a larger audience. Generally the beta cycle should only last a short period.
+A beta version is an early build of an upcoming release. This means that most of the new features are available but there might still be some issues. In the case of the Jellyfin Android apps, we might release a beta version because we expect issues or want to test something with a larger audience. Generally the beta cycle should only last a short period.
 
 ## Should I use a beta version?
 
@@ -30,6 +30,10 @@ If you encounter a problem, we would appreciate a detailed issue with app-logs a
 ## Where do I get the beta?
 
 The beta releases are only available on the Google Play store or in our own repository. Users of F-Droid or the Amazon Appstore can sideload the apk files available in our repository or wait for the release.
+
+### What about the Amazon Appstore?
+
+The Amazon Appstore has no options for beta apps. Therefore, we unfortunately cannot provide beta versions of the app to users who do not have a Play Store on their device.
 
 ### Android TV
 


### PR DESCRIPTION
This post should be published when the Android TV beta is launched and explains how the beta program works and why you should (not) use it.

Feel free to suggest additional questions to add.