### PR TITLE
Added scroll when contributor list is too long for device screen

### DIFF
--- a/content/contribute/_index.md
+++ b/content/contribute/_index.md
@@ -337,6 +337,8 @@ justify: 'center'
 				</div>
 
 ## All the people that brought you Jellyfin
-<object data="https://opencollective.com/jellyfin/contributors.svg?width=1000&button=false" type="image/svg+xml" width="1000"></object>
+<div style="overflow:auto;">
+	<object data="https://opencollective.com/jellyfin/contributors.svg?width=1000&button=false" type="image/svg+xml" width="1000"></object>
+</div>
 <br>
 


### PR DESCRIPTION
This fixes an issue on mobile devices (or shrunken desktop browser windows) where the contributor list width is too long for the device screen. I noticed this on my iPhone while trying to figure out how to contribute. 

<img width="200" alt="bug" src="https://user-images.githubusercontent.com/60938545/131431389-a488a510-f305-414f-9fa4-c38f923c82b9.PNG">

This adds a scrollbar when needed. I tested this on Firefox, Safari, Chrome, Edge, and IE. 

<img width="200" alt="correct-width" src="https://user-images.githubusercontent.com/60938545/131431647-f3ec385b-3870-463b-9d0c-1ab0454652f3.PNG">
<img width="200" alt="scrolling" src="https://user-images.githubusercontent.com/60938545/131431652-2ba9a3fb-373b-4c68-aefe-29f532d3e8f0.PNG">
