### PR TITLE
Always use index.xml for RSS feed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ resources
 .idea/
 
 # Hugo
+.hugo_build.lock
 /public
 
 # Windows

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -6,9 +6,8 @@
   />
   <title>{{ .Title }} {{ if .Title }}-{{ end }} {{ .Site.Title }}</title>
 
-  {{- range .AlternativeOutputFormats -}}
-    {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
-  {{- end -}}
+  <link href="{{ .Site.BaseURL }}index.xml" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
+  <link href="{{ .Site.BaseURL }}index.xml" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
 
   <link rel="shortcut icon" href="/favicon.ico" />
 


### PR DESCRIPTION
So apparently every folder in content is it's own "section". Each section has it's own RSS feed. We don't need that because the only stuff that should be in the feed are the blog posts.
This change simplifies the header.html partial by just linking to the index.xml feed.

Also updated the gitignore, newer versions of hugo create a .lock file when running.

Fixes #117 