### PR TITLE
Update Debian and Ubuntu installation instructions

### DIFF
--- a/.github/workflows/_meta.yaml
+++ b/.github/workflows/_meta.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2.5.0
         with:
-          hugo-version: '0.93.2'
+          hugo-version: '0.95.0'
           extended: true
 
       - name: Build

--- a/content/downloads/_index.md
+++ b/content/downloads/_index.md
@@ -88,21 +88,21 @@ docker run -d -v /srv/jellyfin/config:/config -v /srv/jellyfin/cache:/cache -v /
             }
         </script>
         <div id="deb_repo_stable" style="display:none;">
-            <pre><code>sudo apt install apt-transport-https
-wget -O - https://repo.jellyfin.org/jellyfin_team.gpg.key | sudo apt-key add -
+            <pre><code>sudo apt install curl gnupg
+curl -fsSL https://repo.jellyfin.org/ubuntu/jellyfin_team.gpg.key | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/jellyfin.gpg
 echo "deb [arch=$( dpkg --print-architecture )] https://repo.jellyfin.org/$( awk -F'=' '/^ID=/{ print $NF }' /etc/os-release ) $( awk -F'=' '/^VERSION_CODENAME=/{ print $NF }' /etc/os-release ) main" | sudo tee /etc/apt/sources.list.d/jellyfin.list
 sudo apt update
 sudo apt install jellyfin</code></pre>
-        <p><i>Note:</i> The third command should give you output similar to <code>deb [arch=(architecture)] https://repo.jellyfin.org/(distribution) (release) main"</code>. We support <code>amd64</code>, <code>armhf</code>, and <code>arm64</code> for architectures, <code>debian</code> and <code>ubuntu</code> for distributions, and <code>stretch</code>, <code>buster</code>, and <code>bullseye</code> for Debian releases and <code>xenial</code>, <code>bionic</code>, and <code>focal</code> for Ubuntu releases. If you see something different in your output, you might need to manually modify it. Use the closest equivalent Debian or Ubuntu version instead.</p>
+        <p><i>Note:</i> The third command should give you output similar to <code>deb [arch=(architecture)] https://repo.jellyfin.org/(distribution) (release) main"</code>. We support <code>amd64</code>, <code>armhf</code>, and <code>arm64</code> for architectures, <code>debian</code> and <code>ubuntu</code> for distributions, <code>buster</code> and <code>bullseye</code> for Debian releases and <code>bionic</code>, <code>focal</code>, <code>impish</code> and <code>jammy</code> for Ubuntu releases. If you see something different in your output, you might need to manually modify it. Use the closest equivalent Debian or Ubuntu version instead.</p>
         <p>Once installed, Jellyfin will be running as a service. Manage it with <pre><code>sudo systemctl {action} jellyfin.service</code></pre> or <pre><code>sudo service jellyfin {action}</code></pre></p>
         </div>
         <div id="deb_repo_nightly" style="display:none;">
-            <pre><code>sudo apt install apt-transport-https
-wget -O - https://repo.jellyfin.org/jellyfin_team.gpg.key | sudo apt-key add -
+            <pre><code>sudo apt install curl gnupg
+curl -fsSL https://repo.jellyfin.org/ubuntu/jellyfin_team.gpg.key | gpg --dearmor -o /etc/apt/trusted.gpg.d/jellyfin.gpg
 echo "deb [arch=$( dpkg --print-architecture )] https://repo.jellyfin.org/$( awk -F'=' '/^ID=/{ print $NF }' /etc/os-release ) $( awk -F'=' '/^VERSION_CODENAME=/{ print $NF }' /etc/os-release ) main unstable" | sudo tee /etc/apt/sources.list.d/jellyfin.list
 sudo apt update
 sudo apt install jellyfin</code></pre>
-        <p><i>Note:</i> The third command should give you output similar to <code>deb [arch=(architecture)] https://repo.jellyfin.org/(distribution) (release) main"</code>. We support <code>amd64</code>, <code>armhf</code>, and <code>arm64</code> for architectures, <code>debian</code> and <code>ubuntu</code> for distributions, and <code>stretch</code>, <code>buster</code>, and <code>bullseye</code> for Debian releases and <code>xenial</code>, <code>bionic</code>, and <code>focal</code> for Ubuntu releases. If you see something different in your output, you might need to manually modify it. Use the closest equivalent Debian or Ubuntu version instead.</p>
+        <p><i>Note:</i> The third command should give you output similar to <code>deb [arch=(architecture)] https://repo.jellyfin.org/(distribution) (release) main"</code>. We support <code>amd64</code>, <code>armhf</code>, and <code>arm64</code> for architectures, <code>debian</code> and <code>ubuntu</code> for distributions, <code>buster</code> and <code>bullseye</code> for Debian releases and <code>bionic</code>, <code>focal</code>, <code>impish</code> and <code>jammy</code> for Ubuntu releases. If you see something different in your output, you might need to manually modify it. Use the closest equivalent Debian or Ubuntu version instead.</p>
         <p><i>Note:</i> Both the <code>main</code> and <code>unstable</code> are needed as the <code>jellyfin-ffmpeg</code> package is only in the <code>main</code> component.</p>
         <p>Once installed, Jellyfin will be running as a service. Manage it with <pre><code>sudo systemctl {action} jellyfin.service</code></pre> or <pre><code>sudo service jellyfin {action}</code></pre></p>
         </div>


### PR DESCRIPTION
* Remove EOL distros
* Update Debian and Ubuntu instructions (removed deprecated `apt-key`)
* Bump version of `hugo` to current 0.95.0