### PR TITLE
refactor(ci): use relative uses instead of absolute

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,6 +13,6 @@ on:
 
 jobs:
   build:
-    uses: jellyfin/jellyfin-blog/.github/workflows/_meta.yaml@master
+    uses: ./.github/workflows/_meta.yaml
     with:
       publish: false

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build_publish:
-    uses: jellyfin/jellyfin-blog/.github/workflows/_meta.yaml@master
+    uses: ./.github/workflows/_meta.yaml
     with:
       publish: true
     secrets:


### PR DESCRIPTION
### Description

This PR aims to alter the CI workflow, so that it referes to the `meta` workflow in an relative manner instead of an absolute.
Basically, instead of referring to exactly the meta workflow present in the default branch of this repository it refers to the workflow version within the repository itself (be that a fork or the official one).

for reference https://docs.github.com/en/actions/using-workflows/reusing-workflows#calling-a-reusable-workflow

### Changes

* alter `uses` calls to use reusable workflows in the same repository

### Issues

* n/a