### PR TITLE
Disable publish workflow on forks

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,6 +14,7 @@ on:
 jobs:
   build_publish:
     uses: ./.github/workflows/_meta.yaml
+    if: ${{ contains(github.repository_owner, 'jellyfin') }}
     with:
       publish: true
     secrets:


### PR DESCRIPTION
inspired by https://github.com/jellyfin/jellyfin-docs/pull/687

*not that this repo would get forked besides by org members