### PR TITLE
Add Roku 1.5.0 Announcement

### DIFF
--- a/content/posts/roku-v1.5.0.md
+++ b/content/posts/roku-v1.5.0.md
@@ -1,0 +1,52 @@
+---
+title: 'Jellyfin Roku Release - v1.5.0'
+subtitle: 'Can you hear us now?'
+author: '1hitsong'
+githubusername: '1hitsong'
+date: 2022-07-25T00:00:00-00:00
+justify: 'center'
+---
+
+We are excited to announce the release of Jellyfin 1.5.0 for Roku! This update brings many new features to the Roku client and continues improving existing capabilities.
+
+<!--more-->
+
+## New Features
+
+* Support for Quick Connect
+* Music playback (single song, album play, and Instant Mix)
+* Added “Network/Genre" View Options to libraries
+* New user settings:
+  - Jump back to the first item using back button
+  - Blur unwatched episode images
+  - Hide taglines on movie screen
+  - Use splashscreen image as home background
+  - Use splashscreen image as screensaver background
+* Support for showing pre-roll videos
+* Improved Alpha Picker filter on library screens
+* And many more!
+
+## Bugs Fixed
+* Transcoding issue resulting from 10.8.0 server update
+* Crash when trying to read subtitle track for live tv
+* Periodic startup crash
+
+## Additional Updates
+* More text translations
+* Several important Programmer/Developer updates - making it quicker and easier for us to update the Roku client
+
+## Download Now
+
+Update your installed Jellyfin channel on your Roku device or install Jellyfin from the [Roku store](https://channelstore.roku.com/details/592369/jellyfin).
+
+## Full Release Notes
+
+The full (technical) release notes are available on [GitHub](https://github.com/jellyfin/jellyfin-roku/releases/tag/v1.5.0).
+
+## Contributors
+
+* [@jimdogx](https://github.com/jimdogx)
+* [@candry7731](https://github.com/candry7731)
+* [@1hitsong](https://github.com/1hitsong)
+* [@cewert](https://github.com/cewert)
+* [@renovate](https://github.com/renovate)


### PR DESCRIPTION
Add blog post for Roku 1.5.0 release

1.5.0 is scheduled for release 7/26/2022 at 10 AM PDT (UTC -7), as per Roku's own requirements.
